### PR TITLE
Fix typos

### DIFF
--- a/build-aux/PKGBUILD
+++ b/build-aux/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintaner: Jesse G <isa3laws@gmail.com>
+# Maintainer: Jesse G <isa3laws@gmail.com>
 
 pkgname=resonance
 pkgver=0.1.3

--- a/src/python/extracting.py
+++ b/src/python/extracting.py
@@ -1,4 +1,4 @@
-# extracing.py
+# extracting.py
 # SPDX-FileCopyrightText: 2023 nate-xyz
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/views/preferences_window.rs
+++ b/src/views/preferences_window.rs
@@ -207,8 +207,8 @@ glib::wrapper! {
 
 impl PreferencesWindow {
     pub fn new() -> PreferencesWindow {
-        let prefences: PreferencesWindow = glib::Object::builder::<PreferencesWindow>().build();
-        prefences
+        let preferences: PreferencesWindow = glib::Object::builder::<PreferencesWindow>().build();
+        preferences
     }
 
     fn setup_settings(&self) -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
Found via `codespell -S target -L crate,trough`