### PR TITLE
translation: Remove config.rs file from POTFILES

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -2,7 +2,6 @@ src/main.rs
 src/util.rs
 src/app.rs
 src/database.rs
-src/config.rs
 src/toasts.rs
 src/importer.rs
 src/sort.rs


### PR DESCRIPTION
config.rs does not contain any translatable string and irrelevant for POTFILES.