### PR TITLE
fix syntax error in Spanish translation

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -661,7 +661,7 @@ msgstr ""
 "Si encuentras un error o quieres solicitar una funcionalidad, por favor envía un mensaje "
 "en el repositorio de Github:\n"
 "<a href=\"https://github.com/nate-xyz/resonance/issues\">github.com/nate-xyz/"
-"resonance/issues</a>
+"resonance/issues</a>"
 
 #: src/views/dialog/ui/remove_directory_dialog.ui:6
 msgid "Remove Music Folder?"


### PR DESCRIPTION
Fixes compile error:

```
[3/10] Generating po/es/LC_MESSAGES/resonance-es.mo with a custom command
FAILED: po/es/LC_MESSAGES/resonance.mo 
/usr/bin/msgfmt ../resonance/po/es.po -o po/es/LC_MESSAGES/resonance.mo
../resonance/po/es.po:665: end-of-line within string
/usr/bin/msgfmt: found 1 fatal error
[7/10] Generating data/io.github.nate_xyz.Resonance.desktop with a custom command
FAILED: data/io.github.nate_xyz.Resonance.desktop 
/usr/bin/meson --internal msgfmthelper --msgfmt=/usr/bin/msgfmt ../resonance/data/io.github.nate_xyz.Resonance.desktop.in data/io.github.nate_xyz.Resonance.desktop desktop ../resonance/data/../po
../resonance/data/../po/es.po:665: end-of-line within string
/usr/bin/msgfmt: found 1 fatal error
[8/10] Generating data/io.github.nate_xyz.Resonance.appdata.xml with a custom command
FAILED: data/io.github.nate_xyz.Resonance.appdata.xml 
/usr/bin/meson --internal msgfmthelper --msgfmt=/usr/bin/msgfmt ../resonance/data/io.github.nate_xyz.Resonance.appdata.xml.in data/io.github.nate_xyz.Resonance.appdata.xml xml ../resonance/data/../po
../resonance/data/../po/es.po:665: end-of-line within string
/usr/bin/msgfmt: found 1 fatal error
[9/10] Generating src/resonance_gresource with a custom command
ninja: build stopped: subcommand failed.
```