### PR TITLE
Add Brazilian Portuguese translation and reorder LINGUAS in alphabetical order

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,5 +1,6 @@
 de
 es
 fr
-tr
 id
+pt_BR
+tr

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,0 +1,1056 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the resonance package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Filipe Motta <luizfilipemotta@gmail.com>, 2024.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: resonance\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-04-12 11:49-0400\n"
+"PO-Revision-Date: 2024-03-16 03:47-0300\n"
+"Last-Translator: Filipe Motta <luizfilipemotta@gmail.com>\n"
+"Language-Team: Brazilian Portuguese <>\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Gtranslator 45.3\n"
+"Plural-Forms: nplurals=2; plural=(n > 1)\n"
+
+#. Translator credits. Replace "translator-credits" with your name/username, and optionally an email or URL.
+#. One name per line, please do not remove previous names.
+#: src/app.rs:136
+msgid "translator-credits"
+msgstr "Filipe Motta <luizfilipemotta@gmail.com>"
+
+#: src/database.rs:198
+msgid "Added Folder:"
+msgstr "Pasta adicionada:"
+
+#: src/database.rs:202
+msgid "Unable to add music folder."
+msgstr "Não foi possível adicionar a pasta de músicas."
+
+#. Translators: do not replace {number_of_artists}
+#: src/database.rs:211
+msgid "Added Images!"
+msgstr "Imagens adicionadas!"
+
+#: src/database.rs:211
+msgid "Added {number_of_artists} Artist Images."
+msgstr "{number_of_artists} imagens de artista foram adicionadas."
+
+#. Translators: do not replace {playlist_title}
+#: src/database.rs:221
+msgid "Added Playlist!"
+msgstr "Lista de reprodução adicionada!"
+
+#: src/database.rs:221
+msgid "Playlist «{playlist_title}» has been created!"
+msgstr "A lista de reprodução «{playlist_title}» foi criada!"
+
+#: src/database.rs:225
+msgid "Unable to add playlist."
+msgstr "Não foi possível adicionar a lista de reprodução."
+
+#: src/database.rs:232
+msgid "Duplicated!"
+msgstr "Duplicada!"
+
+#: src/database.rs:232
+msgid "Copied playlist successfully."
+msgstr "A lista de reprodução foi copiada com sucesso."
+
+#: src/database.rs:236
+msgid "Unable to duplicate playlist."
+msgstr "Não foi possível duplicar a lista de reprodução."
+
+#. Translators: do not replace {old_title} or {new_title}
+#: src/database.rs:244
+msgid "Renamed!"
+msgstr "Renomeada!"
+
+#: src/database.rs:244
+msgid "Playlist has been renamed from {old_title} to {new_title}!"
+msgstr "A lista de reprodução foi renomeada de {old_title} para {new_title}!"
+
+#: src/database.rs:248
+msgid "Unable to rename playlist."
+msgstr "Não foi possível renomear a lista de reprodução."
+
+#. Translators: do not replace {removed_directory}
+#: src/database.rs:256
+msgid "Removed:"
+msgstr "Removida:"
+
+#: src/database.rs:256
+msgid "{removed_directory} has been removed from the database."
+msgstr "A pasta {removed_directory} foi removida da base de dados."
+
+#: src/database.rs:260
+msgid "Unable to remove directory."
+msgstr "Não foi possível remover a pasta."
+
+#: src/database.rs:268
+msgid "Deleted."
+msgstr "Deletada."
+
+#: src/database.rs:268
+msgid "Removed playlist successfully!"
+msgstr "A lista de reprodução foi removida com sucesso!"
+
+#: src/database.rs:272
+msgid "Unable to remove playlist."
+msgstr "Não foi possível remover a lista de reprodução."
+
+#: src/database.rs:280
+msgid "Modified."
+msgstr "Modificada."
+
+#: src/database.rs:280
+msgid "Changed playlist successfully!"
+msgstr "A lista de reprodução foi modificada com sucesso!"
+
+#: src/database.rs:284
+msgid "Unable to modify playlist."
+msgstr "Não foi possível modificar a lista de reprodução."
+
+#: src/database.rs:291
+msgid "Added"
+msgstr "Adicionadas"
+
+#: src/database.rs:291
+msgid " tracks to {playlist_title}!"
+msgstr " faixas a {playlist_title}!"
+
+#: src/database.rs:295
+msgid "Unable to add track to playlist."
+msgstr "Não foi possível adicionar a faixa à lista de reprodução."
+
+#: src/database.rs:302
+msgid "Removed"
+msgstr "Removida"
+
+#: src/database.rs:302
+msgid " track from playlist."
+msgstr " faixa da lista de reprodução."
+
+#: src/database.rs:307
+msgid "Unable to remove track from playlist."
+msgstr "Não foi possível remover a faixa da lista de reprodução."
+
+#: src/database.rs:318
+msgid "Unable to reorder playlist."
+msgstr "Não foi possível reordenar a lista de reprodução."
+
+#: src/database.rs:392
+msgid "Unable to load music folders."
+msgstr "Não foi possível carregar as pastas de músicas."
+
+#: src/database.rs:839
+msgid "Tried to add track(s) to playlist that does not exist."
+msgstr "Você tentou adicionar faixas a uma lista de reprodução que não existe."
+
+#. Translators: Only replace "Error!". Reorder if necessary
+#: src/toasts.rs:67
+msgid "<span foreground={ERROR_RED}>Error!</span> {error_msg}"
+msgstr "<span foreground={ERROR_RED}>Erro!</span> {error_msg}"
+
+#: src/views/control_bar.rs:283 src/views/pages/queue/queue_page.rs:243
+msgid "Pause"
+msgstr "Pausar"
+
+#: src/views/control_bar.rs:287 src/views/ui/control_bar.ui:328
+#: src/views/pages/queue/queue_page.rs:247
+#: src/views/pages/queue/ui/queue_page.ui:167
+msgid "Play"
+msgstr "Tocar"
+
+#: src/views/control_bar.rs:504 src/views/pages/queue/queue_page.rs:398
+msgid "Toggle Play Pause"
+msgstr "Alternar Tocar/Pausar"
+
+#: src/views/control_bar.rs:508 src/views/pages/queue/queue_page.rs:402
+msgid "Previous"
+msgstr "Anterior"
+
+#: src/views/control_bar.rs:512 src/views/pages/queue/queue_page.rs:406
+msgid "Next"
+msgstr "Próxima"
+
+#: src/views/control_bar.rs:516 src/views/pages/queue/queue_page.rs:410
+msgid "End Queue"
+msgstr "Encerrar fila"
+
+#: src/views/control_bar.rs:521 src/views/ui/preferences_window.ui:446
+msgid "Playback"
+msgstr "Reprodução"
+
+#: src/views/control_bar.rs:526 src/views/ui/control_bar.ui:505
+msgid "Go to Queue"
+msgstr "Ir para a fila"
+
+#: src/views/control_bar.rs:530
+msgid "Navigate"
+msgstr "Navegar"
+
+#: src/views/generic_flowbox_child.rs:154
+#: src/views/generic_flowbox_child.rs:186
+msgid "{number_of_albums} albums"
+msgstr "{number_of_albums} álbuns"
+
+#: src/views/generic_flowbox_child.rs:155
+#: src/views/generic_flowbox_child.rs:187 src/views/album_card.rs:297
+#: src/views/pages/playlists/playlist_grid_child.rs:235
+#: src/views/pages/playlists/playlist_detail_page.rs:595
+#: src/views/pages/albums/album_grid_child.rs:260
+#: src/views/pages/albums/album_detail_page.rs:307
+msgid "{number_of_tracks} tracks"
+msgstr "{number_of_tracks} faixas"
+
+#: src/views/disc_button.rs:67
+msgid "{album_title}, Disc {disc_number}"
+msgstr "{album_title}, Disco {disc_number}"
+
+#: src/views/disc_button.rs:92
+msgid "Play Disc {disc_number} of {album_title}"
+msgstr "Tocar disco {disc_number} de {album_title}"
+
+#. Translators: only replace "Disc "
+#: src/views/disc_button.rs:98
+msgid "<span weight=\"ultralight\">Disc {disc_number}</span>"
+msgstr "<span weight=\"ultralight\">Disco {disc_number}</span>"
+
+#: src/views/album_card.rs:295
+#: src/views/pages/playlists/playlist_detail_page.rs:593
+#: src/views/pages/albums/album_detail_page.rs:305
+msgid "1 track"
+msgstr "1 faixa"
+
+#: src/views/preferences_window.rs:430 src/views/window.rs:299
+msgid "_Add Music"
+msgstr "_Adicionar músicas"
+
+#: src/views/preferences_window.rs:431 src/views/window.rs:300
+#: src/views/dialog/ui/remove_directory_dialog.ui:25
+#: src/views/dialog/ui/delete_playlist_dialog.ui:11
+#: src/views/dialog/ui/duplicate_playlist_dialog.ui:11
+#: src/views/dialog/ui/rename_playlist_dialog.ui:12
+#: src/views/dialog/ui/save_playlist_dialog.ui:12
+#: src/views/dialog/ui/add_tracks_to_playlist_dialog.ui:10
+#: src/views/dialog/ui/confirm_rename_playlist_dialog.ui:11
+msgid "_Cancel"
+msgstr "_Cancelar"
+
+#: src/views/preferences_window.rs:433 src/views/window.rs:302
+msgid "Select Music Library"
+msgstr "Selecionar biblioteca de músicas"
+
+#: src/views/window.rs:321
+msgid "Unable to add music folder, not a valid directory."
+msgstr ""
+"Não foi possível adicionar pasta de músicas, não é um diretório válido."
+
+#: src/views/window.rs:330
+msgid "Importing Music Folder..."
+msgstr "Importando pasta de músicas..."
+
+#: src/views/window.rs:369 src/views/ui/window.ui:94
+msgid "Welcome to Resonance"
+msgstr "Boas-vindas ao Resonance"
+
+#: src/views/window.rs:370 src/views/ui/window.ui:95
+msgid "Add your music library to get started!"
+msgstr "Adicione sua biblioteca de músicas para começar!"
+
+#: src/views/track_entry.rs:109
+msgid "Play {track_title}"
+msgstr "Tocar {track_title}"
+
+#: src/views/track_entry.rs:110
+msgid "Add {track_title} to Playlist"
+msgstr "Adicionar {track_title} à lista de reprodução"
+
+#: src/views/ui/help-overlay.ui:11
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Geral"
+
+#: src/views/ui/help-overlay.ui:14
+msgctxt "shortcut window"
+msgid "Show Shortcuts"
+msgstr "Mostrar atalhos de teclado"
+
+#: src/views/ui/help-overlay.ui:20
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Encerrar"
+
+#: src/views/ui/control_bar.ui:307 src/views/pages/queue/ui/queue_page.ui:149
+msgid "Previous Track"
+msgstr "Faixa anterior"
+
+#: src/views/ui/control_bar.ui:338 src/views/pages/queue/ui/queue_page.ui:179
+msgid "Next Track"
+msgstr "Próxima faixa"
+
+#: src/views/ui/control_bar.ui:452
+msgid "Loop Queue"
+msgstr "Repetir fila"
+
+#: src/views/ui/control_bar.ui:462 src/views/pages/queue/ui/queue_page.ui:230
+msgid "Loop Current Track"
+msgstr "Repetir faixa atual"
+
+#: src/views/ui/control_bar.ui:474
+msgid "Shuffle Queue"
+msgstr "Embaralhar fila"
+
+#: src/views/ui/album_card.ui:96
+#: src/views/pages/playlists/ui/playlist_grid_child.ui:56
+#: src/views/pages/albums/ui/album_grid_child.ui:56
+#: src/views/pages/albums/ui/album_sidebar.ui:98
+msgid "Play Album"
+msgstr "Tocar álbum"
+
+#: src/views/ui/album_card.ui:116
+#: src/views/pages/playlists/ui/playlist_grid_child.ui:76
+#: src/views/pages/albums/ui/album_grid_child.ui:76
+#: src/views/pages/albums/ui/album_sidebar.ui:116
+msgid "Add Album to Queue"
+msgstr "Adicionar álbum à fila"
+
+#: src/views/ui/album_card.ui:227
+#: src/views/pages/playlists/ui/playlist_detail_page.ui:109
+#: src/views/pages/playlists/ui/playlist_detail_page.ui:298
+#: src/views/pages/albums/ui/album_detail_page.ui:110
+#: src/views/pages/albums/ui/album_detail_page.ui:245
+#: src/views/pages/albums/ui/album_sidebar.ui:254
+msgid "Play Playlist"
+msgstr "Tocar lista de reprodução"
+
+#: src/views/ui/album_card.ui:244
+#: src/views/pages/playlists/ui/playlist_detail_page.ui:129
+#: src/views/pages/playlists/ui/playlist_detail_page.ui:315
+#: src/views/pages/albums/ui/album_detail_page.ui:127
+#: src/views/pages/albums/ui/album_detail_page.ui:262
+#: src/views/pages/albums/ui/album_sidebar.ui:271
+msgid "Add Playlist to Queue"
+msgstr "Adicionar lista de reprodução à fila"
+
+#: src/views/ui/preferences_window.ui:13
+msgid "UI"
+msgstr "IU"
+
+#: src/views/ui/preferences_window.ui:23
+msgid "All"
+msgstr "Tudo"
+
+#: src/views/ui/preferences_window.ui:27 src/views/ui/preferences_window.ui:59
+#: src/views/ui/preferences_window.ui:91 src/views/ui/preferences_window.ui:168
+#: src/views/ui/preferences_window.ui:241
+#: src/views/ui/preferences_window.ui:276
+#: src/views/ui/preferences_window.ui:331
+#: src/views/ui/preferences_window.ui:459
+#: src/views/ui/preferences_window.ui:550
+msgid "Reset"
+msgstr "Redefinir"
+
+#: src/views/ui/preferences_window.ui:33
+msgid "Full Page Back Buttons"
+msgstr "Botões de retorno de tela inteira"
+
+#: src/views/ui/preferences_window.ui:55 src/views/ui/window.ui:313
+msgid "Queue"
+msgstr "Fila"
+
+#: src/views/ui/preferences_window.ui:65
+msgid "Queue Opens By Default"
+msgstr "Abrir fila por padrão"
+
+#: src/views/ui/preferences_window.ui:87
+msgid "Album Grid Page"
+msgstr "Página da grade de álbuns"
+
+#: src/views/ui/preferences_window.ui:97 src/views/ui/preferences_window.ui:174
+msgid "Default sort"
+msgstr "Ordenação padrão"
+
+#: src/views/ui/preferences_window.ui:103
+#: src/views/ui/preferences_window.ui:181
+#: src/views/ui/preferences_window.ui:308
+#: src/views/ui/preferences_window.ui:363
+#: src/views/pages/tracks/ui/track_page.ui:139
+#: src/views/pages/artists/ui/artist_detail_page.ui:164
+#: src/views/pages/albums/ui/album_grid_page.ui:106
+#: src/views/pages/genres/ui/genre_detail_page.ui:164
+msgid "Sort by Album Title"
+msgstr "Ordenar por título do álbum"
+
+#: src/views/ui/preferences_window.ui:104
+#: src/views/ui/preferences_window.ui:182
+#: src/views/ui/preferences_window.ui:288
+#: src/views/ui/preferences_window.ui:364
+#: src/views/pages/tracks/ui/track_page.ui:145
+#: src/views/pages/artists/ui/artist_grid_page.ui:64
+#: src/views/pages/albums/ui/album_grid_page.ui:111
+#: src/views/pages/genres/ui/genre_detail_page.ui:169
+msgid "Sort by Artist Name"
+msgstr "Ordenar por nome de artista"
+
+#: src/views/ui/preferences_window.ui:105
+#: src/views/ui/preferences_window.ui:184
+#: src/views/pages/tracks/ui/track_page.ui:151
+#: src/views/pages/albums/ui/album_grid_page.ui:116
+msgid "Sort by Genre"
+msgstr "Ordenar por gênero musical"
+
+#: src/views/ui/preferences_window.ui:106
+#: src/views/ui/preferences_window.ui:183
+#: src/views/ui/preferences_window.ui:309
+#: src/views/ui/preferences_window.ui:365
+#: src/views/pages/tracks/ui/track_page.ui:157
+#: src/views/pages/artists/ui/artist_detail_page.ui:170
+#: src/views/pages/albums/ui/album_grid_page.ui:121
+#: src/views/pages/genres/ui/genre_detail_page.ui:174
+msgid "Sort by Release Date"
+msgstr "Ordenar por data de lançamento"
+
+#: src/views/ui/preferences_window.ui:107
+#: src/views/ui/preferences_window.ui:310
+#: src/views/ui/preferences_window.ui:366
+#: src/views/pages/artists/ui/artist_detail_page.ui:176
+#: src/views/pages/albums/ui/album_grid_page.ui:126
+#: src/views/pages/genres/ui/genre_detail_page.ui:179
+msgid "Sort by Total Duration"
+msgstr "Ordenar por duração total"
+
+#: src/views/ui/preferences_window.ui:108
+#: src/views/ui/preferences_window.ui:256
+#: src/views/ui/preferences_window.ui:290
+#: src/views/ui/preferences_window.ui:311
+#: src/views/ui/preferences_window.ui:345
+#: src/views/ui/preferences_window.ui:367
+#: src/views/pages/playlists/ui/playlist_grid_page.ui:76
+#: src/views/pages/artists/ui/artist_grid_page.ui:74
+#: src/views/pages/artists/ui/artist_detail_page.ui:182
+#: src/views/pages/albums/ui/album_grid_page.ui:131
+#: src/views/pages/genres/ui/genre_grid_page.ui:145
+#: src/views/pages/genres/ui/genre_detail_page.ui:184
+msgid "Sort by Track Count"
+msgstr "Ordenar por número de faixas"
+
+#: src/views/ui/preferences_window.ui:121
+msgid "Display Album Name and Artist Labels by Default"
+msgstr "Mostrar etiquetas de nome do álbum e artista por padrão"
+
+#: src/views/ui/preferences_window.ui:122
+msgid ""
+"If disabled, these labels are only shown when searching on the album grid "
+"page."
+msgstr ""
+"Se desativado, essas etiquetas só serão mostradas ao pesquisar na página de "
+"grade de álbuns."
+
+#: src/views/ui/preferences_window.ui:139
+msgid "Disable Album Flap"
+msgstr "Desativar aba lateral de álbum"
+
+#: src/views/ui/preferences_window.ui:140
+msgid "Selecting an album will take you straight to the album detail page."
+msgstr ""
+"Selecionar um álbum te levará diretamente á página de detalhes do álbum."
+
+#: src/views/ui/preferences_window.ui:164
+msgid "Track Page"
+msgstr "Página de faixas"
+
+#: src/views/ui/preferences_window.ui:180
+#: src/views/pages/tracks/ui/track_page.ui:133
+msgid "Sort by Track Title"
+msgstr "Ordenar por título da faixa"
+
+#: src/views/ui/preferences_window.ui:197
+msgid "Search Bar Open by Default"
+msgstr "Barra de pesquisa aberta por padrão"
+
+#: src/views/ui/preferences_window.ui:214
+msgid "Display Additional Labels by Default"
+msgstr "Mostrar etiquetas adicionais por padrão"
+
+#: src/views/ui/preferences_window.ui:215
+msgid ""
+"If disabled, track entries only display genre and date labels when searching"
+msgstr ""
+"Se desativado, itens de faixa só mostrarão etiquetas de gênero musical e "
+"data ao pesquisar."
+
+#: src/views/ui/preferences_window.ui:237 src/views/ui/window.ui:371
+msgid "Playlists"
+msgstr "Listas de reprodução"
+
+#: src/views/ui/preferences_window.ui:247
+msgid "Playlist Grid Default Sort"
+msgstr "Ordenação padrão da grade de listas de reprodução"
+
+#: src/views/ui/preferences_window.ui:253
+#: src/views/pages/playlists/ui/playlist_grid_page.ui:61
+msgid "Sort by Playlist Title"
+msgstr "Ordenar por título da lista de reprodução"
+
+#: src/views/ui/preferences_window.ui:254
+#: src/views/pages/playlists/ui/playlist_grid_page.ui:66
+msgid "Sort by Last Modified"
+msgstr "Ordenar por modificação mais recente"
+
+#: src/views/ui/preferences_window.ui:255
+#: src/views/pages/playlists/ui/playlist_grid_page.ui:71
+#: src/views/pages/tracks/ui/track_page.ui:163
+msgid "Sort by Duration"
+msgstr "Ordenar por duração"
+
+#: src/views/ui/preferences_window.ui:272 src/views/ui/window.ui:405
+msgid "Artists"
+msgstr "Artistas"
+
+#: src/views/ui/preferences_window.ui:282
+msgid "Artist Grid Default Sort"
+msgstr "Ordenação padrão da grade de artistas"
+
+#: src/views/ui/preferences_window.ui:289
+#: src/views/ui/preferences_window.ui:344
+#: src/views/pages/artists/ui/artist_grid_page.ui:69
+#: src/views/pages/genres/ui/genre_grid_page.ui:140
+msgid "Sort by Album Count"
+msgstr "Ordenar por número de álbuns"
+
+#: src/views/ui/preferences_window.ui:302
+msgid "Artist Detail Default Sort"
+msgstr "Ordenação padrão dos detalhes de artista"
+
+#: src/views/ui/preferences_window.ui:327 src/views/ui/window.ui:440
+msgid "Genres"
+msgstr "Gêneros musicais"
+
+#: src/views/ui/preferences_window.ui:337
+msgid "Genre Grid Default Sort"
+msgstr "Ordenação padrão da grade de gêneros musicais"
+
+#: src/views/ui/preferences_window.ui:343
+#: src/views/pages/genres/ui/genre_grid_page.ui:135
+msgid "Sort by Genre Name"
+msgstr "Ordenar por nome do gênero musical"
+
+#: src/views/ui/preferences_window.ui:357
+msgid "Genre Detail Default Sort"
+msgstr "Ordenação padrão dos detalhes de gênero musical"
+
+#: src/views/ui/preferences_window.ui:455
+msgid "Playback Settings"
+msgstr "Configurações de reprodução"
+
+#: src/views/ui/preferences_window.ui:467
+msgid "Default Volume"
+msgstr "Volume padrão"
+
+#: src/views/ui/preferences_window.ui:484
+msgid "Shuffle Mode Loops at End"
+msgstr "Modo Aleatório repete ao chegar ao fim"
+
+#: src/views/ui/preferences_window.ui:485
+msgid ""
+"If disabled, shuffle mode will end after last song, like the normal playback "
+"mode"
+msgstr ""
+"Se desabilitado, o Modo Aleatório se encerrará após a última faixa, como no "
+"modo de reprodução normal"
+
+#: src/views/ui/preferences_window.ui:504
+msgid "Last.fm"
+msgstr "Last.fm"
+
+#: src/views/ui/preferences_window.ui:508
+msgid "Last.fm Enabled"
+msgstr "Last.fm ativada"
+
+#: src/views/ui/preferences_window.ui:525
+msgid "Threshold for Scrobble"
+msgstr "Limite para Scrobble"
+
+#: src/views/ui/preferences_window.ui:526
+msgid "The percentage of the song that must play before scrobbled"
+msgstr ""
+"A porcentagem da faixa que deve ser tocada para contabilizar o scrobble"
+
+#: src/views/ui/preferences_window.ui:545
+msgid "Discord"
+msgstr "Discord"
+
+#: src/views/ui/preferences_window.ui:557
+msgid "Discord Rich Presence Enabled"
+msgstr "Presença detalhada no Discord ativada"
+
+#: src/views/ui/preferences_window.ui:582
+msgid "Folder(s)"
+msgstr "Pasta(s)"
+
+#: src/views/ui/preferences_window.ui:596
+msgid "Add Folder"
+msgstr "Adicionar pasta"
+
+#: src/views/ui/preferences_window.ui:611
+msgid "Add Music Directory"
+msgstr "Adicionar diretório de músicas"
+
+#: src/views/ui/preferences_window.ui:626
+#: data/io.github.nate_xyz.Resonance.gschema.xml:6
+#: data/io.github.nate_xyz.Resonance.gschema.xml:7
+msgid "Music Folders"
+msgstr "Pastas de músicas"
+
+#: src/views/ui/window.ui:170
+msgid "Add Music"
+msgstr "Adicionar música"
+
+#: src/views/ui/window.ui:257
+msgid "Go Back"
+msgstr "Voltar"
+
+#: src/views/ui/window.ui:268
+msgid "Sort"
+msgstr "Ordenar"
+
+#: src/views/ui/window.ui:277 src/views/pages/queue/ui/queue_sidebar.ui:109
+msgid "Search"
+msgstr "Buscar"
+
+#: src/views/ui/window.ui:325
+msgid "Albums"
+msgstr "Álbuns"
+
+#: src/views/ui/window.ui:358
+msgid "Tracks"
+msgstr "Faixas"
+
+#: src/views/ui/window.ui:509
+msgid "_Preferences"
+msgstr "_Preferências"
+
+#: src/views/ui/window.ui:517
+msgid "_About Resonance"
+msgstr "_Sobre o Resonance"
+
+#. <property name="hexpand">true</property>
+#. <property name="halign">fill</property>
+#: src/views/ui/album_track_entry.ui:29
+msgid "Play Track"
+msgstr "Tocar faixa"
+
+#: src/views/dialog/rename_playlist_dialog.rs:105
+msgid "Cannot rename playlist, no name entered."
+msgstr ""
+"Não foi possível renomear a lista de reprodução, nenhum nome foi inserido."
+
+#: src/views/dialog/save_playlist_dialog.rs:110
+msgid "Playlist #{new_playlist_number}"
+msgstr "Lista de reprodução #{new_playlist_number}"
+
+#: src/views/dialog/add_tracks_to_playlist_dialog.rs:133
+msgid "Unable to add tracks to playlist, no playlist selected"
+msgstr ""
+"Não foi possível adicionar faixas à lista de reprodução, nenhuma lista de "
+"reprodução selecionada"
+
+#: src/views/dialog/alpha_dialog.rs:70
+msgid ""
+"Resonance is early alpha stage software, there will be bugs.\n"
+"If you find a bug or would like to request a feature, please open an issue "
+"on the github repo:\n"
+"<a href=\"https://github.com/nate-xyz/resonance/issues\">github.com/nate-xyz/"
+"resonance/issues</a>"
+msgstr ""
+"Resonance é um programa em estágio alfa inicial, problemas irão aparecer.\n"
+"Se você encontrar um problema ou quiser solicitar uma funcionalidade, por "
+"favor abra uma <i>issue</i> no repositório do GitHub:\n"
+"<a href=\"https://github.com/nate-xyz/resonance/issues\">github.com/nate-xyz/"
+"resonance/issues</a>"
+
+#: src/views/dialog/ui/remove_directory_dialog.ui:6
+msgid "Remove Music Folder?"
+msgstr "Remover pasta de músicas?"
+
+#: src/views/dialog/ui/remove_directory_dialog.ui:14
+msgid ""
+"Are you sure you want to remove this music folder from your database? You "
+"will be unable to access the music within the folder unless you add it again."
+msgstr ""
+"Tem certeza de que deseja remover esta pasta de músicas de sua base de "
+"dados? Você não poderá acessar as músicas de dentro da pasta a não ser que "
+"você a adicione novamente."
+
+#: src/views/dialog/ui/remove_directory_dialog.ui:26
+msgid "_Remove"
+msgstr "_Remover"
+
+#: src/views/dialog/ui/delete_playlist_dialog.ui:6
+msgid "Delete Playlist?"
+msgstr "Excluir lista de reprodução?"
+
+#: src/views/dialog/ui/delete_playlist_dialog.ui:7
+msgid ""
+"Are you sure you want to permanently delete this playlist? You will be "
+"unable to access it again after deletion."
+msgstr ""
+"Tem certeza de que deseja excluir permanentemente esta lista de reprodução? "
+"Você não poderá mais acessá-la após a exclusão."
+
+#: src/views/dialog/ui/delete_playlist_dialog.ui:12
+msgid "_Delete"
+msgstr "_Excluir"
+
+#: src/views/dialog/ui/duplicate_playlist_dialog.ui:6
+msgid "Confirm Duplication"
+msgstr "Confirmar duplicação"
+
+#: src/views/dialog/ui/duplicate_playlist_dialog.ui:7
+msgid "Are you sure you want to duplicate this playlist?"
+msgstr "Tem certeza de que deseja duplicar esta lista de reprodução?"
+
+#: src/views/dialog/ui/duplicate_playlist_dialog.ui:12
+msgid "_Duplicate"
+msgstr "_Duplicar"
+
+#: src/views/dialog/ui/rename_playlist_dialog.ui:6
+msgid "Rename Playlist?"
+msgstr "Renomear lista de reprodução?"
+
+#: src/views/dialog/ui/rename_playlist_dialog.ui:13
+msgid "_Rename"
+msgstr "_Renomear"
+
+#: src/views/dialog/ui/rename_playlist_dialog.ui:22
+#: src/views/pages/queue/ui/queue_sidebar.ui:34
+msgid "Playlist"
+msgstr "Lista de reprodução"
+
+#: src/views/dialog/ui/save_playlist_dialog.ui:6
+msgid "Save Playlist?"
+msgstr "Salvar lista de reprodução?"
+
+#: src/views/dialog/ui/save_playlist_dialog.ui:13
+msgid "_Save"
+msgstr "_Salvar"
+
+#: src/views/dialog/ui/save_playlist_dialog.ui:24
+msgid "Playlist Title"
+msgstr "Título da lista de reprodução"
+
+#: src/views/dialog/ui/save_playlist_dialog.ui:31
+msgid "Playlist Description (Optional)"
+msgstr "Descrição da lista de reprodução (opcional)"
+
+#: src/views/dialog/ui/add_tracks_to_playlist_dialog.ui:6
+msgid "Select Playlist"
+msgstr "Escolher lista de reprodução"
+
+#: src/views/dialog/ui/add_tracks_to_playlist_dialog.ui:11
+msgid "_Add"
+msgstr "_Adicionar"
+
+#: src/views/dialog/ui/confirm_rename_playlist_dialog.ui:6
+msgid "Modify Playlist?"
+msgstr "Modificar lista de reprodução?"
+
+#: src/views/dialog/ui/confirm_rename_playlist_dialog.ui:7
+msgid "Confirm these changes."
+msgstr "Confirmar alterações."
+
+#: src/views/dialog/ui/confirm_rename_playlist_dialog.ui:12
+msgid "_Change"
+msgstr "_Modificar"
+
+#: src/views/dialog/ui/confirm_rename_playlist_dialog.ui:28
+msgid "Modified Title"
+msgstr "Título modificado"
+
+#: src/views/dialog/ui/confirm_rename_playlist_dialog.ui:67
+msgid "Modified Description"
+msgstr "Descrição modificada"
+
+#: src/views/dialog/ui/alpha_dialog.ui:6
+msgid "Early Software Warning ⚠️"
+msgstr "Aviso de Software em Fase Inicial ⚠️"
+
+#: src/views/dialog/ui/alpha_dialog.ui:10
+msgid "Don't Show Again"
+msgstr "Não mostrar novamente"
+
+#: src/views/dialog/ui/alpha_dialog.ui:11
+msgid "Ok!"
+msgstr "Ok!"
+
+#: src/views/pages/queue/queue_sidebar.rs:264
+msgid "{time_remaining} remaining"
+msgstr "{time_remaining} restantes"
+
+#: src/views/pages/queue/ui/queue_page.ui:201
+msgid "Toggle Playlist Sidebar"
+msgstr "Ativar/Desativar barra lateral de lista de reprodução"
+
+#: src/views/pages/queue/ui/queue_page.ui:218
+msgid "Loop Playlist"
+msgstr "Repetir lista de reprodução"
+
+#: src/views/pages/queue/ui/queue_page.ui:242
+msgid "Shuffle Playlist"
+msgstr "Embaralhar lista de reprodução"
+
+#: src/views/pages/queue/ui/queue_sidebar_track_entry.ui:105
+msgid "Remove Track From Queue"
+msgstr "Remover faixa da fila"
+
+#: src/views/pages/queue/ui/queue_sidebar.ui:47
+msgid "time remaining"
+msgstr "tempo restante"
+
+#: src/views/pages/queue/ui/queue_sidebar.ui:70
+msgid "Clear Queue"
+msgstr "Limpar fila"
+
+#: src/views/pages/queue/ui/queue_sidebar.ui:90
+msgid "Edit Queue"
+msgstr "Editar fila"
+
+#: src/views/pages/queue/ui/queue_sidebar.ui:98
+msgid "Save"
+msgstr "Salvar"
+
+#: src/views/pages/playlists/playlist_detail_page.rs:711
+#: src/views/pages/playlists/ui/playlist_detail_page.ui:442
+msgid "Edit Playlist"
+msgstr "Editar lista de reprodução"
+
+#: src/views/pages/playlists/playlist_detail_page.rs:723
+msgid "Finish Edit Playlist"
+msgstr "Finalizar edição da lista de reprodução"
+
+#: src/views/pages/playlists/ui/playlist_grid_page.ui:59
+msgid "Sort Playlist Grid"
+msgstr "Ordenar grade de listas de reprodução"
+
+#: src/views/pages/playlists/ui/playlist_detail_row.ui:183
+#: src/views/pages/tracks/ui/track_page_row.ui:165
+msgid "Add Track to Queue"
+msgstr "Adicionar faixa à fila"
+
+#: src/views/pages/playlists/ui/playlist_detail_row.ui:208
+msgid "Remove Track From Playlist"
+msgstr "Remover faixa da lista de reprodução"
+
+#: src/views/pages/playlists/ui/playlist_detail_page.ui:408
+msgid "Delete Playlist"
+msgstr "Excluir lista de reprodução"
+
+#: src/views/pages/playlists/ui/playlist_detail_page.ui:425
+msgid "Duplicate Playlist"
+msgstr "Duplicar lista de reprodução"
+
+#: src/views/pages/tracks/ui/track_page.ui:31
+msgid "Scroll to Top"
+msgstr "Rolar para o topo"
+
+#: src/views/pages/tracks/ui/track_page.ui:43
+msgid "Scroll to Bottom"
+msgstr "Rolar para o fim"
+
+#: src/views/pages/tracks/ui/track_page.ui:74
+msgid "Title, Album, & Artist"
+msgstr "Título, Álbum & Artista"
+
+#: src/views/pages/tracks/ui/track_page.ui:75
+msgid "Track Title"
+msgstr "Título da faixa"
+
+#: src/views/pages/tracks/ui/track_page.ui:76
+#: src/views/pages/albums/ui/album_grid_page.ui:39
+msgid "Album Title"
+msgstr "Título do álbum"
+
+#: src/views/pages/tracks/ui/track_page.ui:77
+#: src/views/pages/albums/ui/album_grid_page.ui:40
+msgid "Artist"
+msgstr "Artista"
+
+#: src/views/pages/tracks/ui/track_page.ui:78
+#: src/views/pages/albums/ui/album_grid_page.ui:41
+msgid "Genre"
+msgstr "Gênero musical"
+
+#: src/views/pages/tracks/ui/track_page.ui:79
+#: src/views/pages/albums/ui/album_grid_page.ui:42
+msgid "Release Date"
+msgstr "Data de lançamento"
+
+#: src/views/pages/tracks/ui/track_page.ui:131
+msgid "Sort Track List"
+msgstr "Ordenar lista de faixas"
+
+#: src/views/pages/artists/ui/artist_grid_page.ui:62
+msgid "Sort Artist Grid"
+msgstr "Ordenar grade de artistas"
+
+#: src/views/pages/artists/ui/artist_detail_page.ui:97
+msgid "Play all Artist Albums"
+msgstr "Tocar todos os álbuns deste artista"
+
+#: src/views/pages/artists/ui/artist_detail_page.ui:109
+msgid "Add all Artist Albums to Queue"
+msgstr "Adicionar todos os álbuns deste artista à fila"
+
+#: src/views/pages/artists/ui/artist_detail_page.ui:162
+msgid "Sort Artist Albums"
+msgstr "Ordenar álbuns deste artista"
+
+#: src/views/pages/albums/ui/album_sidebar.ui:33
+msgid "Close Album Sidebar"
+msgstr "Fechar barra lateral de álbum"
+
+#: src/views/pages/albums/ui/album_sidebar.ui:135
+#: src/views/pages/albums/ui/album_sidebar.ui:289
+msgid "View Album Page"
+msgstr "Ver página do álbum"
+
+#: src/views/pages/albums/ui/album_grid_page.ui:38
+msgid "Title & Artist"
+msgstr "Título & Artista"
+
+#: src/views/pages/albums/ui/album_grid_page.ui:104
+msgid "Sort Album Grid"
+msgstr "Ordenar grade de álbuns"
+
+#: src/views/pages/genres/ui/genre_grid_page.ui:133
+msgid "Sort Genre Grid"
+msgstr "Ordenar grade de gêneros musicais"
+
+#: src/views/pages/genres/ui/genre_detail_page.ui:95
+msgid "Play all Genre Albums"
+msgstr "Tocar todos os álbuns deste gênero musical"
+
+#: src/views/pages/genres/ui/genre_detail_page.ui:107
+msgid "Add all Genre Albums to Queue"
+msgstr "Adicionar todos os álbuns deste gênero músical"
+
+#: src/views/pages/genres/ui/genre_detail_page.ui:162
+msgid "Sort Genre Albums"
+msgstr "Ordenar álbuns deste gênero musical"
+
+#: data/io.github.nate_xyz.Resonance.desktop.in:3
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:6
+msgid "Resonance"
+msgstr "Resonance"
+
+#: data/io.github.nate_xyz.Resonance.desktop.in:4
+msgid "Music Player"
+msgstr "Tocador de Música"
+
+#. Translators: Search terms to find this application. Do not translate or localize the semicolons! The list must also end with a semicolon.
+#: data/io.github.nate_xyz.Resonance.desktop.in:11
+msgid "music;sound;player;media;audio;playlist;"
+msgstr "música;som;tocador;reprodutor;mídia;áudio;lista;playlist;"
+
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:7
+msgid "Harmonize your listening experience"
+msgstr "Harmonize sua experiência de ouvir"
+
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:8
+msgid "nate-xyz"
+msgstr "nate-xyz"
+
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:10
+msgid ""
+"Resonance is an intuitive music player application written in Rust and "
+"Python, with a clean user interface built using the GTK4 / Libadwaita "
+"framework. Resonance lets you effortlessly manage and play your music "
+"collection, with support for all the common music file formats."
+msgstr ""
+"Resonance é um aplicativo intuitivo de tocador de música escrito em Rust e "
+"Python, com uma interface de usuário limpa construída com o framework GTK4 / "
+"Libadwaita. Resonance permite que você gerencie e toque sua coleção de "
+"música facilmente, com suporte a todos os formatos de arquivos de músicas "
+"mais comuns."
+
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:11
+msgid "Features:"
+msgstr "Recursos:"
+
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:13
+msgid "UI updates to reflect currently playing track's cover art colors"
+msgstr ""
+"A interface de usuário se atualiza para refletir as cores da arte de capa da "
+"faixa que estiver tocando no momento"
+
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:14
+msgid "Playlist creation and modification"
+msgstr "Criação e modificação de listas de reprodução"
+
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:15
+msgid "Control the player through MPRIS"
+msgstr "Controle o tocador pelo MPRIS"
+
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:16
+msgid "Discord Rich Presence integration"
+msgstr "Integração com a presença detalhada no Discord"
+
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:17
+msgid "Last.fm scrobbling"
+msgstr "Scrobbling no Last.fm"
+
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:18
+msgid "Import tags with the Mutagen library"
+msgstr "Importe etiquetas com a biblioteca Mutagen"
+
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:19
+msgid ""
+"No tag editing (intentionally out of scope to keep Resonance a music player "
+"only)"
+msgstr ""
+"Sem edição de etiquetas (intencionalmente fora do escopo, para manter o "
+"Resonance apenas como um tocador de música)"
+
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:21
+msgid ""
+"⚠️ RESONANCE IS EARLY STAGE ALPHA RELEASE SOFTWARE (THERE ARE BUGS, PLEASE "
+"OPEN ISSUES) ⚠️"
+msgstr ""
+"⚠️ RESONANCE É UM PROGRAMA EM ESTÁGIO ALFA INICIAL (PROBLEMAS EXISTEM, POR "
+"FAVOR ABRA <i>ISSUES</i>) ⚠️"
+
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:35
+msgid "MPRIS bugfix"
+msgstr "Correção de problemas no MPRIS"
+
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:36
+msgid "Dark mode by default"
+msgstr "Modo escuro por padrão"
+
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:37
+msgid "Various UI improvements"
+msgstr "Várias melhoras na interface de usuário"
+
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:44
+msgid "Add Last.fm support"
+msgstr "Suporte ao Last.fm adicionado"
+
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:51
+msgid "Use album cover art if track cover art empty"
+msgstr "Usar arte da capa do álbum se a arte da capa da faixa estiver ausente"
+
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:52
+msgid "URI encoding for player pipeline bugfix"
+msgstr "Codificação de URI para a correção de problemas no pipeline do tocador"
+
+#: data/io.github.nate_xyz.Resonance.appdata.xml.in:53
+msgid "UI improvements"
+msgstr "Melhoras na interface de usuário"


### PR DESCRIPTION
This PR includes the following changes:
1. Addition of a pt_BR.po file to the /po directory, containing a Brazilian Portuguese translation for the app, based on the latest PO file available in the repo;
2. Edit to the LINGUAS file to include a "pt_BR" line, in order to make the Brazilian Portuguese translation available to the app;
3. Reordering of the lines in the LINGUAS file in order to keep the language identifiers in alphabetical order.

Hope my work can be of use and help the app get more Brazilian Portuguese-speaking users. Thanks for the app!