### PR TITLE
Appdata related changes

### DIFF
--- a/data/io.github.nate_xyz.Resonance.appdata.xml.in
+++ b/data/io.github.nate_xyz.Resonance.appdata.xml.in
@@ -69,10 +69,6 @@
   </custom>
   <content_rating type="oars-1.1"/>
 
-	<categories>
-    <category>Audio</category>
-		<category>Music</category>
-  </categories>
 
 	<screenshots>
     <screenshot>

--- a/data/io.github.nate_xyz.Resonance.appdata.xml.in
+++ b/data/io.github.nate_xyz.Resonance.appdata.xml.in
@@ -5,7 +5,10 @@
 	<project_license>GPL-3.0-or-later</project_license>
 	<name>Resonance</name>
 	<summary>Harmonize your listening experience</summary>
-	<developer_name>nate-xyz</developer_name>
+	<developer_name translate="no">nate-xyz</developer_name>
+    <developer id="io.github.nate_xyz">
+      <name translate="no">nate-xyz</name>
+    </developer>
 	<description>
 	  <p>Resonance is an intuitive music player application written in Rust and Python, with a clean user interface built using the GTK4 / Libadwaita framework. Resonance lets you effortlessly manage and play your music collection, with support for all the common music file formats.</p>
     <p>Features:</p>

--- a/data/io.github.nate_xyz.Resonance.appdata.xml.in
+++ b/data/io.github.nate_xyz.Resonance.appdata.xml.in
@@ -72,9 +72,8 @@
   </custom>
   <content_rating type="oars-1.1"/>
 
-
-	<screenshots>
-    <screenshot>
+  <screenshots>
+    <screenshot type="default">
       <image>https://raw.githubusercontent.com/nate-xyz/resonance/main/data/screenshots/resonance2.png</image>
     </screenshot>
     <screenshot>

--- a/data/io.github.nate_xyz.Resonance.appdata.xml.in
+++ b/data/io.github.nate_xyz.Resonance.appdata.xml.in
@@ -36,7 +36,7 @@
 
 	<releases>
     <release version="0.1.3" date="2023-04-09">
-      <description>
+      <description translate="no">
         <ul>
           <li>MPRIS bugfix</li>
           <li>Dark mode by default</li>
@@ -45,14 +45,14 @@
       </description>
     </release>
     <release version="0.1.2" date="2023-04-06">
-      <description>
+      <description translate="no">
         <ul>
           <li>Add Last.fm support</li>
         </ul>
       </description>
     </release>
     <release version="0.1.1" date="2023-04-04">
-      <description>
+      <description translate="no">
         <ul>
           <li>Use album cover art if track cover art empty</li>
           <li>URI encoding for player pipeline bugfix</li>

--- a/data/io.github.nate_xyz.Resonance.appdata.xml.in
+++ b/data/io.github.nate_xyz.Resonance.appdata.xml.in
@@ -25,8 +25,10 @@
   <launchable type="desktop-id">io.github.nate_xyz.Resonance.desktop</launchable>
   <translation type="gettext">resonance</translation>
 
-	<url type="homepage">https://github.com/nate-xyz/resonance</url>
+  <url type="homepage">https://github.com/nate-xyz/resonance</url>
   <url type="bugtracker">https://github.com/nate-xyz/resonance/issues</url>
+  <url type="vcs-browser">https://github.com/nate-xyz/resonance</url>
+  <url type="translate">https://github.com/nate-xyz/resonance/tree/main/po</url>
   <url type="donation">https://ko-fi.com/natexyz</url>
 
 	<releases>

--- a/data/io.github.nate_xyz.Resonance.appdata.xml.in
+++ b/data/io.github.nate_xyz.Resonance.appdata.xml.in
@@ -23,6 +23,7 @@
   </description>
 	<provides>io.github.nate_xyz.Resonance.desktop</provides>
   <launchable type="desktop-id">io.github.nate_xyz.Resonance.desktop</launchable>
+  <translation type="gettext">resonance</translation>
 
 	<url type="homepage">https://github.com/nate-xyz/resonance</url>
   <url type="bugtracker">https://github.com/nate-xyz/resonance/issues</url>
@@ -57,7 +58,6 @@
     <release version="0.1.0" date="2023-03-30"/>
   </releases>
 
-	<translation type="gettext">resonance</translation>
   <kudos>
     <kudo>ModernToolkit</kudo>
     <kudo>HiDpiIcon</kudo>


### PR DESCRIPTION
### appdata: Mark release descriptions as untranslatable

GNOME automatically excludes release descriptions on Damned Lies (GNOME Translation Platform). It's a good practice to follow the GNOME way.

This can streamline the translation process, allowing translators to focus their efforts on more critical and user-facing aspects of the application.

### appdata: Fix missing default screenshot

At least one screenshot must be marked as default.

### appdata: Add developer block

> A developer tag with an id attribute and a name child tag must be present. The name must be the author or developer of the application.

More information: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#developer-name

### appdata: Remove categories

> If there’s a launchable defined for a desktop application, they are pulled from the desktop file. Defining them separately in the Metainfo file will override the contents of the desktop file.

More information: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#categories-and-keywords

### appdata: Add several URLs

- Add vcs-browser URL to show the source code repository.
- Add translate tag to show translation repository.

More information: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#url

### appdata: Move translation tag

Move translation tag to make it easier to find.
