### PR TITLE
flatpak: Update GNOME runtime to 46

### DIFF
--- a/flatpak/io.github.nate_xyz.Resonance.json
+++ b/flatpak/io.github.nate_xyz.Resonance.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.nate_xyz.Resonance",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "44",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"

--- a/flatpak/io.github.nate_xyz.Resonance.json
+++ b/flatpak/io.github.nate_xyz.Resonance.json
@@ -17,8 +17,7 @@
         "--filesystem=xdg-download:ro",
         "--filesystem=xdg-music:ro",
         "--filesystem=xdg-run/app/com.discordapp.Discord:create",
-        "--filesystem=xdg-run/discord-ipc-0",
-        "--talk-name=org.freedesktop.portal.OpenURI"
+        "--filesystem=xdg-run/discord-ipc-0"
     ],
     "build-options" : {
         "append-path" : "/usr/lib/sdk/rust-stable/bin",


### PR DESCRIPTION
### flatpak: Update runtime

Update Resonance runtime to version 46 since runtime version 44 has reached end-of-life.

### flatpak: remove portal talk name

> The finish-args in the manifest has a --talk-name= starting with org.freedesktop.portal..
> Portal interfaces do not need to be manually added. These are allowed by Flatpak by default.

Source: https://docs.flathub.org/docs/for-app-authors/linter/#finish-args-portal-talk-name